### PR TITLE
Add jrp hostname support to minimal configuration checks

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -61,7 +61,7 @@ scripts
 .local/share/wallpapers
 {{ end -}}
 
-{{ if or (eq .chezmoi.username "root") (contains "jrh" .chezmoi.hostname) -}}
+{{ if or (eq .chezmoi.username "root") (contains "jrh" .chezmoi.hostname) (contains "jrp" .chezmoi.hostname) -}}
 # Root and jrh-hostname machines: shell + starship only, no KDE Plasma, wallpapers, or Spicetify
 scripts
 .icons

--- a/.chezmoitemplates/nushell_config.nu.tmpl
+++ b/.chezmoitemplates/nushell_config.nu.tmpl
@@ -50,7 +50,7 @@ fastfetch -c ~/.smallfetch.jsonc
 {{- else }}
 alias eza = eza --icons
 alias "ls e" = eza --icons
-{{- if not (or (eq .chezmoi.username "root") (contains "jrh" .chezmoi.hostname)) }}
+{{- if not (or (eq .chezmoi.username "root") (contains "jrh" .chezmoi.hostname) (contains "jrp" .chezmoi.hostname)) }}
 alias fix-crackle = pw-metadata -n settings 0 clock.force-quantum 500
 {{- end }}
 {{- end }}

--- a/.chezmoitemplates/nushell_env.nu.tmpl
+++ b/.chezmoitemplates/nushell_env.nu.tmpl
@@ -25,7 +25,7 @@
 #path add ($env.HOME | path join ".cargo" "bin")
 #path add ($env.HOME | path join ".dotnet" "tools")
 #path add ($env.HOME | path join "bin")
-{{- else if not (or (eq .chezmoi.username "root") (contains "jrh" .chezmoi.hostname)) }}
+{{- else if not (or (eq .chezmoi.username "root") (contains "jrh" .chezmoi.hostname) (contains "jrp" .chezmoi.hostname)) }}
 use std "path add"
 $env.PATH = ($env.PATH | split row (char esep))
 

--- a/dot_bashrc.tmpl
+++ b/dot_bashrc.tmpl
@@ -1,11 +1,11 @@
-{{- $minimal := or (eq .chezmoi.username "root") (contains "jrh" .chezmoi.hostname) -}}
+{{- $minimal := or (eq .chezmoi.username "root") (contains "jrh" .chezmoi.hostname) (contains "jrp" .chezmoi.hostname) -}}
 {{ if not (eq .chezmoi.username "root") -}}
 # Smallfetch
 fastfetch -c ~/.smallfetch.jsonc
 
 {{ end -}}
 # Starship
-{{ if contains "jrh" .chezmoi.hostname -}}
+{{ if or (contains "jrh" .chezmoi.hostname) (contains "jrp" .chezmoi.hostname) -}}
 eval -- "$(/usr/bin/starship init bash --print-full-init)"
 {{ else -}}
 eval -- "$(starship init bash --print-full-init)"

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -104,7 +104,7 @@ source $ZSH/oh-my-zsh.sh
 # alias zshconfig="mate ~/.zshrc"
 # alias ohmyzsh="mate ~/.oh-my-zsh"
 eval "$(starship init zsh)"
-{{- else if contains "jrh" .chezmoi.hostname -}}
+{{- else if or (contains "jrh" .chezmoi.hostname) (contains "jrp" .chezmoi.hostname) -}}
 # If you come from bash you might have to change your $PATH.
 # export PATH=$HOME/bin:$HOME/.local/bin:/usr/local/bin:$PATH
 


### PR DESCRIPTION
## Summary
Extended minimal configuration checks across dotfiles to include machines with "jrp" in their hostname, alongside the existing "jrh" hostname check. This ensures consistent behavior for both hostname patterns.

## Key Changes
- **dot_bashrc.tmpl**: Added "jrp" hostname check to the `$minimal` variable and Starship initialization condition
- **.chezmoiignore**: Extended the minimal configuration exclusion rule to include "jrp" hostnames
- **.chezmoitemplates/nushell_config.nu.tmpl**: Added "jrp" hostname check to the alias configuration condition
- **.chezmoitemplates/nushell_env.nu.tmpl**: Added "jrp" hostname check to the environment path configuration condition
- **dot_zshrc.tmpl**: Added "jrp" hostname check to the Starship initialization condition

## Implementation Details
All changes follow the existing pattern by adding `(contains "jrp" .chezmoi.hostname)` to the relevant conditional checks alongside the existing `(contains "jrh" .chezmoi.hostname)` conditions. This ensures that machines with "jrp" in their hostname receive the same minimal configuration treatment as "jrh" machines (shell + starship only, without KDE Plasma, wallpapers, or other desktop environment features).

https://claude.ai/code/session_01HBX6pbvVcDN9NGNY8rFvgz