### PR TITLE
Guard CachyOS fish config source behind a file existence check

### DIFF
--- a/dot_config/fish/config.fish.tmpl
+++ b/dot_config/fish/config.fish.tmpl
@@ -1,4 +1,7 @@
-source /usr/share/cachyos-fish-config/cachyos-config.fish
+# only source the CachyOS fish config on CachyOS
+if test -f /usr/share/cachyos-fish-config/cachyos-config.fish
+    source /usr/share/cachyos-fish-config/cachyos-config.fish
+end
 
 # overwrite greeting
 # potentially disabling fastfetch


### PR DESCRIPTION
## Summary
- `dot_config/fish/config.fish.tmpl` unconditionally sourced `/usr/share/cachyos-fish-config/cachyos-config.fish`, which only exists on CachyOS.
- Since `dot_config/fish` applies on every non-Windows profile (desktop, root, jrh/jrp, darwin), this would throw a "No such file or directory" error on fish startup anywhere else.
- Wraps the source in a runtime `test -f` check instead of a chezmoi-template conditional — self-correcting if the file ever moves or the distro changes, and matches the existing precedent of deck-dotfiles' bashrc checking `/etc/os-release` at runtime rather than gating at apply-time.

## Test plan
- [x] Rendered the template with `chezmoi execute-template` for both the root branch and a simulated non-root branch — output identical apart from the intended `fish_greeting` behavior, confirming the CachyOS guard applies uniformly.
- [x] Ran a full `chezmoi apply` against a scratch destination and confirmed `.config/fish/config.fish` renders with the new `if test -f ... end` guard.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HBX6pbvVcDN9NGNY8rFvgz)_