### PR TITLE
Add runtime checks for optional tools and nix dev-init profile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ This is a rough list of dependencies an applications used in the configuration:
 - fastfetch
 - eza, `ls` replacement (Linux)
 - starship
+- fish (Linux, optional) — see below
+- [nix](https://nixos.org/) (Linux, optional) — only needed for the `dev-init` profile
+
+### fish and the `dev-init` nix profile
+The fish config checks for its tools at runtime instead of assuming them, so it applies cleanly on a machine that is missing some of them:
+- the `ls`/`ll`/`la`/`lt`/`lg` helpers are only defined when `eza` is installed, so `ls` otherwise falls back to fish's own
+- the fastfetch greeting and `starship init` are each skipped when that binary isn't on `PATH`
+
+`.config/fish/conf.d/dev-init.fish` picks up a nix profile named `dev-init` when one exists, and does nothing at all when it doesn't. It looks in `$DEV_INIT_PROFILE`, `$XDG_STATE_HOME/nix/profiles`, `~/.local/state/nix/profiles`, `~/.local/share/nix/profiles`, `/nix/var/nix/profiles/per-user/$USER` and `/nix/var/nix/profiles`, taking the first that actually has a `bin/`. From that profile it puts `bin` on `PATH`, adds `share/man` to `MANPATH`, wires up the `share/fish/vendor_*` directories that NixOS would normally handle itself, and exports `DEV_INIT_PROFILE`. Since `conf.d` is read before `config.fish`, tools that come from the profile (`eza`, `starship`, …) satisfy the checks above. If a `dev-init` binary ends up on `PATH` it also gets a `di` shorthand, skipped when something else already owns that name.
 
 ### Windows-specific
 - [nushell](https://www.nushell.sh/) and/or PowerShell

--- a/dot_config/fish/conf.d/dev-init.fish
+++ b/dot_config/fish/conf.d/dev-init.fish
@@ -1,0 +1,79 @@
+# nix `dev-init` profile/package support.
+#
+# Everything here is detected at runtime: if the profile isn't installed on this
+# machine, or the binaries it should provide are missing, every block below is
+# skipped. That keeps this same config usable on boxes without nix.
+
+# Candidate profile locations, first match wins. $DEV_INIT_PROFILE is checked
+# first so the location can be forced from the environment; the rest cover
+# `nix profile` (XDG state dir), older nix (XDG data dir), and the `nix-env -p`
+# per-user and system profile dirs.
+set -l dev_init_candidates \
+    $DEV_INIT_PROFILE \
+    $XDG_STATE_HOME/nix/profiles/dev-init \
+    $HOME/.local/state/nix/profiles/dev-init \
+    $HOME/.local/share/nix/profiles/dev-init \
+    /nix/var/nix/profiles/per-user/$USER/dev-init \
+    /nix/var/nix/profiles/dev-init
+
+set -l dev_init_profile
+for candidate in $dev_init_candidates
+    # bin/ is the "only if the necessary bins are there" check: a profile
+    # symlink left pointing at nothing usable counts as absent.
+    if test -d $candidate/bin
+        set dev_init_profile $candidate
+        break
+    end
+end
+
+if set -q dev_init_profile[1]
+    set -gx DEV_INIT_PROFILE $dev_init_profile
+
+    # --path --global rather than the fish_add_path default: $fish_user_paths is
+    # universal on this setup, and a path baked in there would outlive the
+    # profile it came from. No --move on purpose -- prepend only when the entry
+    # is missing, so a nested fish inside `nix develop` keeps that shell's tools
+    # in front instead of having these yanked over them.
+    fish_add_path --global --path --prepend $dev_init_profile/bin
+
+    if test -d $dev_init_profile/share/man
+        if not contains -- $dev_init_profile/share/man $MANPATH
+            set -gx MANPATH $dev_init_profile/share/man $MANPATH
+        end
+        # A trailing empty entry keeps man's own default search path reachable.
+        if not contains -- "" $MANPATH
+            set -gx --append MANPATH ""
+        end
+    end
+
+    # nix packages ship their fish integration under share/fish/vendor_*. NixOS
+    # wires these up itself; a plain profile on another distro does not.
+    set -l dev_init_completions $dev_init_profile/share/fish/vendor_completions.d
+    if test -d $dev_init_completions; and not contains -- $dev_init_completions $fish_complete_path
+        # Prepended so completions match the binaries put first on PATH above.
+        set -g fish_complete_path $dev_init_completions $fish_complete_path
+    end
+
+    set -l dev_init_functions $dev_init_profile/share/fish/vendor_functions.d
+    if test -d $dev_init_functions; and not contains -- $dev_init_functions $fish_function_path
+        # Appended so the profile can't shadow ~/.config/fish/functions.
+        set -g --append fish_function_path $dev_init_functions
+    end
+
+    for conf in $dev_init_profile/share/fish/vendor_conf.d/*.fish
+        source $conf
+    end
+end
+
+# Command-level support is checked separately: `dev-init` can be on PATH from
+# the default nix profile with no dev-init profile dir of its own.
+if command -q dev-init
+    # `di` shorthand, skipped if something else on this box already owns the
+    # name, as a command or as a function. --wraps borrows dev-init's own
+    # completions.
+    if not command -q di; and not functions -q di
+        function di --wraps dev-init --description 'dev-init'
+            dev-init $argv
+        end
+    end
+end

--- a/dot_config/fish/config.fish.tmpl
+++ b/dot_config/fish/config.fish.tmpl
@@ -10,29 +10,37 @@ function fish_greeting
 end
 {{- else }}
 function fish_greeting
-	fastfetch -c ~/.smallfetch.jsonc
+	if command -q fastfetch
+		fastfetch -c ~/.smallfetch.jsonc
+	end
 end
 {{- end }}
 
 # eza functions
-function ls --description 'eza as ls'
-    eza --group-directories-first --icons=auto $argv
+# only defined when eza is installed, so `ls` falls back to the real one
+# elsewhere. conf.d runs first, so an eza from the nix dev-init profile counts.
+if command -q eza
+    function ls --description 'eza as ls'
+        eza --group-directories-first --icons=auto $argv
+    end
+
+    function ll --description 'long list'
+        eza -l --group-directories-first --icons=auto --git $argv
+    end
+
+    function la --description 'long list, all files'
+        eza -la --group-directories-first --icons=auto --git $argv
+    end
+
+    function lt --description 'tree view'
+        eza --tree --level=2 --icons=auto --group-directories-first $argv
+    end
+
+    function lg --description 'long list with git status'
+        eza -l --git --git-repos --icons=auto --group-directories-first $argv
+    end
 end
 
-function ll --description 'long list'
-    eza -l --group-directories-first --icons=auto --git $argv
+if command -q starship
+    starship init fish | source
 end
-
-function la --description 'long list, all files'
-    eza -la --group-directories-first --icons=auto --git $argv
-end
-
-function lt --description 'tree view'
-    eza --tree --level=2 --icons=auto --group-directories-first $argv
-end
-
-function lg --description 'long list with git status'
-    eza -l --git --git-repos --icons=auto --group-directories-first $argv
-end
-
-starship init fish | source


### PR DESCRIPTION
## Summary
This change makes the fish shell configuration more portable by adding runtime checks for optional tools and introducing support for the nix `dev-init` profile. Instead of assuming tools like `eza`, `starship`, and `fastfetch` are installed, the config now gracefully handles their absence.

## Key Changes

- **New `dev-init.fish` configuration**: Added comprehensive support for nix's `dev-init` profile that:
  - Searches multiple standard nix profile locations (`$DEV_INIT_PROFILE`, XDG state/data dirs, system profile dirs)
  - Adds the profile's `bin/` directory to `PATH` when found
  - Integrates `share/man`, `share/fish/vendor_completions.d`, and `share/fish/vendor_functions.d` directories
  - Provides a `di` shorthand for the `dev-init` command when available
  - Gracefully skips all setup if no profile is found

- **Runtime command checks in `config.fish`**: Wrapped tool-dependent configurations with `command -q` checks:
  - `fastfetch` greeting only runs if the binary exists
  - `eza` functions (`ls`, `ll`, `la`, `lt`, `lg`) only defined when `eza` is installed, allowing fallback to system `ls`
  - `starship` initialization only runs if the binary exists

- **Updated README**: Documented the optional dependencies and explained how the `dev-init` profile integration works

## Implementation Details

- The `dev-init.fish` script uses `--global --path --prepend` for PATH modifications to ensure profile tools take precedence while respecting nested nix shells
- Completions are prepended to `fish_complete_path` to match the tool priority, while functions are appended to avoid shadowing user-defined functions
- The `di` shorthand respects existing commands/functions to avoid conflicts
- All checks are non-fatal, making the same config usable across machines with different tool availability

https://claude.ai/code/session_01QJdzDHV812RqRXHsHM32Z4