### PR TITLE
Add direnv hook initialization to fish shell config

### DIFF
--- a/dot_config/fish/config.fish.tmpl
+++ b/dot_config/fish/config.fish.tmpl
@@ -41,6 +41,13 @@ if command -q eza
     end
 end
 
+# direnv hook
+# only when direnv is installed; conf.d runs first, so a direnv from the nix
+# dev-init profile counts.
+if command -q direnv
+    direnv hook fish | source
+end
+
 if command -q starship
     starship init fish | source
 end


### PR DESCRIPTION
## Summary
Added direnv hook initialization to the fish shell configuration file to enable automatic environment management when direnv is installed.

## Changes
- Added conditional direnv hook initialization in `dot_config/fish/config.fish.tmpl`
- The hook is only sourced when the `direnv` command is available
- Positioned before the starship initialization to ensure proper load order
- Includes a comment noting that direnv from the nix dev-init profile is recognized since `conf.d` runs first

## Implementation Details
The direnv hook is initialized using the standard pattern: `direnv hook fish | source`, which allows direnv to automatically load `.envrc` files in project directories.

https://claude.ai/code/session_01RguhNPRvzPapAH4VqNVqAT