### PR TITLE
Add dev-init profile and direnv support to zsh and bash

### DIFF
--- a/.chezmoitemplates/shell_dev-init.sh.tmpl
+++ b/.chezmoitemplates/shell_dev-init.sh.tmpl
@@ -1,0 +1,93 @@
+{{- $shell := . }}
+# nix `dev-init` profile/package support, plus the direnv hook.
+#
+# Mirrors .config/fish/conf.d/dev-init.fish. Everything here is detected at
+# runtime: if the profile isn't installed on this machine, or the binaries it
+# should provide are missing, every block below is skipped. That keeps this
+# same config usable on boxes without nix.
+
+# Candidate profile locations, first match wins. $DEV_INIT_PROFILE is checked
+# first so the location can be forced from the environment; the rest cover
+# `nix profile` (XDG state dir), older nix (XDG data dir), and the `nix-env -p`
+# per-user and system profile dirs.
+_dev_init_profile=
+for _dev_init_candidate in \
+    "$DEV_INIT_PROFILE" \
+    "${XDG_STATE_HOME:+$XDG_STATE_HOME/nix/profiles/dev-init}" \
+    "$HOME/.local/state/nix/profiles/dev-init" \
+    "$HOME/.local/share/nix/profiles/dev-init" \
+    "/nix/var/nix/profiles/per-user/${USER:-$LOGNAME}/dev-init" \
+    "/nix/var/nix/profiles/dev-init"
+do
+    [ -n "$_dev_init_candidate" ] || continue
+    # bin/ is the "only if the necessary bins are there" check: a profile
+    # symlink left pointing at nothing usable counts as absent.
+    if [ -d "$_dev_init_candidate/bin" ]; then
+        _dev_init_profile=$_dev_init_candidate
+        break
+    fi
+done
+unset _dev_init_candidate
+
+if [ -n "$_dev_init_profile" ]; then
+    export DEV_INIT_PROFILE="$_dev_init_profile"
+
+    # Prepend only when the entry is missing, so a nested shell inside
+    # `nix develop` keeps that shell's tools in front instead of having these
+    # yanked over them.
+    case ":$PATH:" in
+        *":$_dev_init_profile/bin:"*) ;;
+        *) PATH="$_dev_init_profile/bin:$PATH" ;;
+    esac
+    export PATH
+
+    if [ -d "$_dev_init_profile/share/man" ]; then
+        case ":$MANPATH:" in
+            *":$_dev_init_profile/share/man:"*) ;;
+            *) MANPATH="$_dev_init_profile/share/man:$MANPATH" ;;
+        esac
+        # A trailing empty entry keeps man's own default search path reachable.
+        case "$MANPATH" in
+            *:) ;;
+            *) MANPATH="$MANPATH:" ;;
+        esac
+        export MANPATH
+    fi
+
+{{ if eq $shell "zsh" }}
+    # nix packages ship zsh completions under share/zsh/site-functions. NixOS
+    # wires these up itself; a plain profile on another distro does not.
+    # compinit has already run by this point (oh-my-zsh), so re-run it once
+    # after extending fpath to actually pick the new completions up.
+    if [ -d "$_dev_init_profile/share/zsh/site-functions" ] &&
+        [[ -z ${fpath[(r)$_dev_init_profile/share/zsh/site-functions]} ]]; then
+        fpath=("$_dev_init_profile/share/zsh/site-functions" $fpath)
+        autoload -Uz compinit && compinit -u
+    fi
+{{ else }}
+    # bash-completion loads completions on demand out of
+    # $BASH_COMPLETION_USER_DIR/completions, which is where nix puts them.
+    # Only set when the user hasn't pointed it somewhere else already.
+    if [ -z "$BASH_COMPLETION_USER_DIR" ] &&
+        [ -d "$_dev_init_profile/share/bash-completion/completions" ]; then
+        export BASH_COMPLETION_USER_DIR="$_dev_init_profile/share/bash-completion"
+    fi
+{{ end }}
+fi
+unset _dev_init_profile
+
+# Command-level support is checked separately: `dev-init` can be on PATH from
+# the default nix profile with no dev-init profile dir of its own.
+if command -v dev-init >/dev/null 2>&1; then
+    # `di` shorthand, skipped if something else on this box already owns the
+    # name (command, function or alias).
+    if ! command -v di >/dev/null 2>&1 && ! alias di >/dev/null 2>&1; then
+        alias di='dev-init'
+    fi
+fi
+
+# direnv hook, only when direnv is installed -- including a direnv that came
+# from the dev-init profile put on PATH above.
+if command -v direnv >/dev/null 2>&1; then
+    eval "$(direnv hook {{ $shell }})"
+fi

--- a/README.md
+++ b/README.md
@@ -41,13 +41,18 @@ This is a rough list of dependencies an applications used in the configuration:
 - starship
 - fish (Linux, optional) — see below
 - [nix](https://nixos.org/) (Linux, optional) — only needed for the `dev-init` profile
+- [direnv](https://direnv.net/) (optional) — hooked into fish, zsh and bash when installed
 
-### fish and the `dev-init` nix profile
+### fish, zsh, bash and the `dev-init` nix profile
 The fish config checks for its tools at runtime instead of assuming them, so it applies cleanly on a machine that is missing some of them:
 - the `ls`/`ll`/`la`/`lt`/`lg` helpers are only defined when `eza` is installed, so `ls` otherwise falls back to fish's own
 - the fastfetch greeting and `starship init` are each skipped when that binary isn't on `PATH`
 
 `.config/fish/conf.d/dev-init.fish` picks up a nix profile named `dev-init` when one exists, and does nothing at all when it doesn't. It looks in `$DEV_INIT_PROFILE`, `$XDG_STATE_HOME/nix/profiles`, `~/.local/state/nix/profiles`, `~/.local/share/nix/profiles`, `/nix/var/nix/profiles/per-user/$USER` and `/nix/var/nix/profiles`, taking the first that actually has a `bin/`. From that profile it puts `bin` on `PATH`, adds `share/man` to `MANPATH`, wires up the `share/fish/vendor_*` directories that NixOS would normally handle itself, and exports `DEV_INIT_PROFILE`. Since `conf.d` is read before `config.fish`, tools that come from the profile (`eza`, `starship`, …) satisfy the checks above. If a `dev-init` binary ends up on `PATH` it also gets a `di` shorthand, skipped when something else already owns that name.
+
+The same detection is shared by zsh and bash through the `shell_dev-init.sh.tmpl` chezmoi template, appended to `.zshrc` and `.bashrc`: same candidate list and same `bin/` check, exporting `DEV_INIT_PROFILE`, prepending `bin` to `PATH` (only when it isn't already there) and adding `share/man` to `MANPATH`. For completions zsh gets `share/zsh/site-functions` prepended to `fpath` followed by a single `compinit` re-run (oh-my-zsh has already run it by that point), and bash gets `BASH_COMPLETION_USER_DIR` pointed at the profile's `share/bash-completion` unless it is already set. The `di` shorthand is an alias there, defined only when `dev-init` is on `PATH` and nothing else owns the name.
+
+Both shells also get the direnv hook (`eval "$(direnv hook zsh|bash)"`), and only when a `direnv` binary is actually on `PATH` — including one that came from the `dev-init` profile, since the profile block runs first.
 
 ### Windows-specific
 - [nushell](https://www.nushell.sh/) and/or PowerShell

--- a/dot_bashrc.tmpl
+++ b/dot_bashrc.tmpl
@@ -27,3 +27,5 @@ fi
 unset __conda_setup
 # <<< conda initialize <<<
 {{ end -}}
+
+{{ template "shell_dev-init.sh.tmpl" "bash" }}

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -462,3 +462,6 @@ export PATH="$BUN_INSTALL/bin:$PATH"
 # fnm
 eval "$(fnm env --use-on-cd --shell zsh)"
 {{- end }}
+
+
+{{ template "shell_dev-init.sh.tmpl" "zsh" }}


### PR DESCRIPTION
Ports the runtime detection already in `.config/fish/conf.d/dev-init.fish` to zsh and bash, through a shared chezmoi template (`.chezmoitemplates/shell_dev-init.sh.tmpl`) appended to `.zshrc` and `.bashrc`. Everything stays guarded, so the same config still applies cleanly on machines with neither nix nor direnv.

## What it does

**dev-init nix profile** — same candidate list as fish (`$DEV_INIT_PROFILE`, `$XDG_STATE_HOME/nix/profiles`, `~/.local/state/nix/profiles`, `~/.local/share/nix/profiles`, `/nix/var/nix/profiles/per-user/$USER`, `/nix/var/nix/profiles`), first one with a real `bin/` wins. From it:
- exports `DEV_INIT_PROFILE`
- prepends `bin` to `PATH`, but only when the entry is missing, so a nested shell inside `nix develop` keeps its own tools in front
- prepends `share/man` to `MANPATH` and keeps a trailing empty entry so man's default search path stays reachable
- zsh: prepends `share/zsh/site-functions` to `fpath` and re-runs `compinit` once — oh-my-zsh has already run it by the point the snippet is sourced
- bash: points `BASH_COMPLETION_USER_DIR` at the profile's `share/bash-completion` unless it is already set, which is enough for bash-completion's on-demand loading
- `di` shorthand as an alias when a `dev-init` binary is on `PATH` and nothing else owns the name

**direnv** — `eval "$(direnv hook zsh|bash)"`, only when a `direnv` binary exists. The profile block runs first, so a direnv that comes from the `dev-init` profile counts.

## Notes

- zsh applies to all three template branches (root, jrh/jrp hosts, and the default one); bash applies to both the minimal and full branches.
- Reads `X` before writing: `PATH`, `MANPATH` and `BASH_COMPLETION_USER_DIR` are all left alone when they already carry the value, so re-sourcing the rc file is idempotent.
- README documents the zsh/bash behavior next to the existing fish section and lists direnv as an optional dep.

## Testing

chezmoi isn't available in this environment, so the template was rendered by hand for both shells. The bash rendering passes `bash -n` and was sourced in a clean `env -i` bash against a fake profile dir: `PATH`, `MANPATH`, `BASH_COMPLETION_USER_DIR` and the `di` alias all come out right, and with no profile and no direnv present the snippet is a no-op that exits 0. The zsh rendering could not be executed — no zsh binary here — so its `fpath`/`compinit` block is reviewed but unrun.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqbS9XVCdssHPGz9PCnVfC)_