### PR TITLE
Guard zsh/bash startup on tools that may not be installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ The same detection is shared by zsh and bash through the `shell_dev-init.sh.tmpl
 
 Both shells also get the direnv hook (`eval "$(direnv hook zsh|bash)"`), and only when a `direnv` binary is actually on `PATH` — including one that came from the `dev-init` profile, since the profile block runs first.
 
+The zsh and bash configs apply the same runtime checks to the rest of their tools, so a machine that is missing one doesn't error on every new shell: `starship init`, the fastfetch greeting (with its `smallfetch`/`archbtw` aliases), the `eza`-backed `ls` alias and `fnm env` are each skipped when that binary isn't installed, and `ls` falls back to the real one.
+
 ### Windows-specific
 - [nushell](https://www.nushell.sh/) and/or PowerShell
 - [starship](https://starship.rs/) installed to `C:\Program Files\starship\bin\starship.exe`

--- a/dot_bashrc.tmpl
+++ b/dot_bashrc.tmpl
@@ -1,14 +1,21 @@
 {{- $minimal := or (eq .chezmoi.username "root") (contains "jrh" .chezmoi.hostname) (contains "jrp" .chezmoi.hostname) -}}
 {{ if not (eq .chezmoi.username "root") -}}
 # Smallfetch
-fastfetch -c ~/.smallfetch.jsonc
+# only when fastfetch is installed
+if command -v fastfetch >/dev/null 2>&1; then
+    fastfetch -c ~/.smallfetch.jsonc
+fi
 
 {{ end -}}
 # Starship
 {{ if or (contains "jrh" .chezmoi.hostname) (contains "jrp" .chezmoi.hostname) -}}
-eval -- "$(/usr/bin/starship init bash --print-full-init)"
+if [ -x /usr/bin/starship ]; then
+    eval -- "$(/usr/bin/starship init bash --print-full-init)"
+fi
 {{ else -}}
-eval -- "$(starship init bash --print-full-init)"
+if command -v starship >/dev/null 2>&1; then
+    eval -- "$(starship init bash --print-full-init)"
+fi
 {{ end -}}
 {{ if not $minimal }}
 

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -103,7 +103,9 @@ source $ZSH/oh-my-zsh.sh
 # Example aliases
 # alias zshconfig="mate ~/.zshrc"
 # alias ohmyzsh="mate ~/.oh-my-zsh"
-eval "$(starship init zsh)"
+if command -v starship >/dev/null 2>&1; then
+    eval "$(starship init zsh)"
+fi
 {{- else if or (contains "jrh" .chezmoi.hostname) (contains "jrp" .chezmoi.hostname) -}}
 # If you come from bash you might have to change your $PATH.
 # export PATH=$HOME/bin:$HOME/.local/bin:/usr/local/bin:$PATH
@@ -216,15 +218,21 @@ source $ZSH/oh-my-zsh.sh
 source /etc/restic-env
 
 # Smallfetch
-fastfetch -c ~/.smallfetch.jsonc
-alias smallfetch="fastfetch -c ~/.smallfetch.jsonc"
+if command -v fastfetch >/dev/null 2>&1; then
+    fastfetch -c ~/.smallfetch.jsonc
+    alias smallfetch="fastfetch -c ~/.smallfetch.jsonc"
+fi
 
 # eza, zoxide
-alias ls='eza --icons' # list
+if command -v eza >/dev/null 2>&1; then
+    alias ls='eza --icons' # list
+fi
 #alias cd='z' # cd = zoxide
 
 #eval "$(zoxide init zsh)"
-eval "$(starship init zsh)"
+if command -v starship >/dev/null 2>&1; then
+    eval "$(starship init zsh)"
+fi
 {{- else -}}
 # If you come from bash you might have to change your $PATH.
 export PATH=$HOME/.dotnet/tools:$HOME/.local/bin:$HOME/bin:$HOME/bin:/usr/local/bin:$HOME/.cargo/bin:$PATH
@@ -375,7 +383,9 @@ source $ZSH/oh-my-zsh.sh
 #}
 
 
-alias ls='eza --icons' # list
+if command -v eza >/dev/null 2>&1; then
+    alias ls='eza --icons' # list
+fi
 #alias cd='z' # cd = zoxide
 # alias un='yay -R' # uninstall package
 # alias up='yay -Syu' # update system/package/aur
@@ -412,8 +422,11 @@ alias vc='code' # gui code editor
 
 #eval "$(zoxide init zsh)"
 
-fastfetch -c ~/.smallfetch.jsonc
-alias smallfetch="fastfetch -c ~/.smallfetch.jsonc"
+if command -v fastfetch >/dev/null 2>&1; then
+    fastfetch -c ~/.smallfetch.jsonc
+    alias smallfetch="fastfetch -c ~/.smallfetch.jsonc"
+    alias archbtw='clear;fastfetch'
+fi
 #smallfetch
 #fortune -s -n 100
 
@@ -421,7 +434,6 @@ export PATH=$PATH:{{ .chezmoi.homeDir }}/.spicetify
 
 # for fun :)
 alias fucking='sudo' # because its funny
-alias archbtw='clear;fastfetch'
 alias baseddino="fortune -s -n 150 -o | cowsay -f stegosaurus"
 
 #eval "$(zellij setup --generate-auto-start zsh)"
@@ -449,7 +461,9 @@ fi
 unset __conda_setup
 # <<< conda initialize <<<
 #source ~/bira.zsh-theme
-eval "$(starship init zsh)"
+if command -v starship >/dev/null 2>&1; then
+    eval "$(starship init zsh)"
+fi
 
 
 # bun completions
@@ -460,7 +474,10 @@ export BUN_INSTALL="$HOME/.bun"
 export PATH="$BUN_INSTALL/bin:$PATH"
 
 # fnm
-eval "$(fnm env --use-on-cd --shell zsh)"
+# only when fnm is installed, so a machine without it doesn't error on startup
+if command -v fnm >/dev/null 2>&1; then
+    eval "$(fnm env --use-on-cd --shell zsh)"
+fi
 {{- end }}
 
 


### PR DESCRIPTION
Fixes the reported startup error:

```
/Users/joshr/.zshrc:235: command not found: fnm
```

`eval "$(fnm env --use-on-cd --shell zsh)"` ran unconditionally at the end of the default zsh branch, so any machine without fnm printed that on every new shell. It's now behind a `command -v fnm` check.

While in there, the same check is applied to the other binaries these rc files assumed — the fish config already works this way, and these are the same class of failure on a machine that's missing one:

- `starship init` — all three zsh branches, both bash branches. The jrh/jrp bash branch hardcodes `/usr/bin/starship`, so that one tests `[ -x /usr/bin/starship ]` rather than `command -v`.
- the fastfetch greeting, together with the `smallfetch` and `archbtw` aliases that shell out to it
- the `eza`-backed `ls` alias, so `ls` falls back to the real one instead of a broken alias

No aliases move between branches: `archbtw` stays only in the default branch that already had it, and the jrh/jrp branch does not gain it.

Untouched: the conda block already degrades to a plain `PATH` export when conda is missing, and the bun completions line is already `[ -s … ] &&` guarded.

## Testing

No chezmoi or zsh in this environment. Each of the three zsh branches and both bash branches was rendered by hand and parses cleanly under `bash -n` — enough to confirm the added `if`/`fi` blocks balance, though the zsh-specific syntax around them is unexecuted. Worth an `exec zsh` on the mac that hit the error to confirm the message is gone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqbS9XVCdssHPGz9PCnVfC)_